### PR TITLE
An edit for the sample code and for the narrative

### DIFF
--- a/box-model-work/index.html
+++ b/box-model-work/index.html
@@ -46,7 +46,7 @@ Vice tumblr pork belly poutine cray. 3 wolf moon etsy synth, meditation gochujan
 
 Post-ironic chillwave chartreuse pinterest. Tote bag 90's single-origin coffee, small batch ennui lumbersexual crucifix normcore semiotics venmo shoreditch gentrify lo-fi forage. Lomo try-hard gluten-free retro. 3 wolf moon normcore biodiesel, authentic blue bottle meggings polaroid bicycle rights narwhal knausgaard offal. Williamsburg scenester distillery shabby chic gastropub mustache. Neutra intelligentsia asymmetrical gentrify, banjo microdosing ramps. Semiotics intelligentsia godard shoreditch fashion axe tattooed messenger bag, chicharrones gluten-free cliche actually church-key mixtape meditation man bun.</p>
 
-        <h3><a href="http://http://slipsum.com/">SLIpsum</a></h3>
+        <h3><a href="http://slipsum.com/">SLIpsum</a></h3>
             <p>CENSORED!</p>   
 
             <div id="square1"></div>

--- a/readme.md
+++ b/readme.md
@@ -417,9 +417,11 @@ So, without clears, change the heights of square1 and square2 to 200px and absol
 
 Note how our "square2" div is positioned to the top left of the container and "square1" to the top right. This was done to illustrate that absolute positioning doesn't care what order the elements appear in your html.
 
+<!--   ********** This bit needs to be rewritten.  Following the instructions from the top doesn't actually hide square3 or square4, so the following is confusing.  From here:   ********** -->
 Also, notice how we can't see square3 or square4? They are being covered up by our absolute-positioned "square2" div (remember absolute positioning removes the element from the document).
 
 We can reveal those missing divs by declaring their absolute position in the bottom left and right of our container:
+<!--  ********** to here   ********** -->
 
 ```css
 #square3 {

--- a/readme.md
+++ b/readme.md
@@ -361,21 +361,6 @@ Specifying `position:absolute` _removes the element from the document_ and place
 
 
 
-##### Relative Positioning
-
-Declaring `position:relative` allows you to position the element top, bottom, left, or right relative to where it would normally occur.
-
-```css
-#square1 {
-    background-color: red;
-    height: 100px;
-    width: 100px;
-    position:relative;
-    top: 0;
-    left: 40px;
-}
-```
-
 ## Floats and Clears - Intro 
 
 The float property specifies whether or not a box (or an element) should float; essentially, it determines whether text will be wrapped around the element.


### PR DESCRIPTION
In the _index.html_, there's a small error in the URL to the Samuel L. Ipsum page.

In the discussion, the paragraph about "relative positioning" appears twice.  The code I'm suggesting be removed is exactly the same as the paragraph above where "relative positioning" is referenced.

And, the discussion references that square3 and square4 are covered up at one point by making square1 and square2 200px tall and moving them to the top corners.  The instructions as followed actually leaves these divs in the center of the screen.  Therefore, the instruction is confusing since it explains something the student isn't seeing.
